### PR TITLE
Centralize and merge base action modules into Behavior

### DIFF
--- a/Solar2D/main.lua
+++ b/Solar2D/main.lua
@@ -30,16 +30,12 @@ env.goPage = "narration"
 -- env.book = "snowMan"
 -- env.goPage = "page1"
 
---env.book = "TheLastSpark"
--- env.goPage = "forest"
---env.goPage = "cabin"
-
 --
-env.mode = "development"
--- env.mode = "production"
 
+-- env.mode  = "development"
+-- env.mode  = "debug"
 -- env.mode = "production" -- need kwik5-plugin src from kwiksher's repo
---env.mode = "behaviorTree"
+env.mode = "behaviorTree"
 
 --
 if env.mode == "development" or env.mode == "debug" then
@@ -74,26 +70,33 @@ elseif env.mode == "behaviorTree" then
   require("custom.components.myComponent")
 
   local resourcePath = system.pathForFile("", system.ResourceDirectory)
-
---  local appPath = "/App/TheLastSpark/behaviorTree"
-  local appPath = "/App/BTree_test/behaviorTree"
-
-  package.path = resourcePath .. appPath.."/?.lua;" .. resourcePath .. appPath.."/?/?.lua;"..package.path
+  local appPath = "/Behavior/" .. env.book
+  local kwikPath = "/lua_modules/kwiksher/kwik"
+  package.path = resourcePath .. appPath .. "/?.lua;" ..
+                 resourcePath .. appPath .. "/?/?.lua;" ..
+                 resourcePath .. kwikPath .. "/?.lua;" ..
+                 resourcePath .. kwikPath .. "/?/?.lua;" ..
+                 package.path
 
     -- Require Composer for scene management
   local composer = require("composer")
 
-  -- Start with the forest scene
-  -- composer.gotoScene("views.forest.forestScene")
-  -- composer.gotoScene("views.cabin.cabinScene")
-  composer.gotoScene("views.animation.animationScene")
+  -- Start with the selected behavior-tree scene
+  local sceneModule = "Behavior."..env.book..".views."..env.goPage.."."..env.goPage.."Scene"
+  local okScene, sceneOrErr = pcall(require, sceneModule)
+  if not okScene then
+    print("Failed to load scene module:", sceneModule)
+    print(sceneOrErr)
+    return
+  end
 
+  composer.gotoScene(sceneModule)
 
   --Start automated test after scene loads
   -- timer.performWithDelay(1000, function()
-  --     print("\n=== Starting Automated Cabin Test (Jump to Choices) ===\n")
-  --     local cabinTest = require("tests.cabinSceneTest")
-  --     cabinTest.start()
+  --     print("\n=== Starting Automated Test (Jump to Choices) ===\n")
+  --     local sceneTest = require("tests."..env.goPage.."SceneTest")
+  --     sceneTest.start()
   -- end)
   return
 end


### PR DESCRIPTION
Move duplicated base_*.lua action modules from
Behavior/BTree_test/actions and Behavior/TheLastSpark/actions into a
single shared Behavior location (Solar2D/Behavior). Merge overlapping
implementations (choice, narration, show_choices, wait) into unified
modules with compatibility shims so both BTree_test and TheLastSpark can
require Behavior.base_*. Update all action requires to point to
Behavior.base_* and remove the old duplicated files. This cleans up
duplication and ensures both projects use the same base action logic.
chore(config): toggle active book and page in main.lua
Fix narration box layouts in fight and calm scenes

Update TheLastSpark fight and calm scenes to use the shared Behavior
dialogue layout for narration box and next-button positioning and
sizing. Ensure textWidth, textHeight, fontSize, dialog dimensions, and
next button dimensions/position are consistent with the shared layout.
Verify the retreat scene already matched the shared layout so no changes
were needed there.
Enable TheLastSpark as active book and page

Uncomment TheLastSpark book and forest page to make TheLastSpark the
active content for runtime. This reverses previous test selections
(BTree_test and narration) so the app starts with the forest scene of
TheLastSpark for development and testing.
Align TheLastSpark dialogue layout with Behavior config

Use Behavior configuration values for textWidth and textHeight in
TheLastSpark scenes so narration/choice-result layouts match
cabin/forest text field settings. Updated force_door, arcane_markings,
and retreat dialogue interfaces to include textWidth and textHeight from
Behavior, and cleaned up main.lua commented env settings to keep the
BTree_test/narration defaults.
Align forest narration layout with cabin

Update TheLastSpark forest scene narration to use the same text layout
options as the cabin narration. This brings in textWidth, textHeight,
and fontSize parameters from the shared Behavior configuration into the
forest dialogue interface options so the dialogue initialization behaves
consistently. Kept box positioning and overall dialog sizing unchanged;
this only aligns the missing text field layout settings.
Pass narration fontSize to BTree_test dialogue interface

Update BTree_test narration scene to pass fontSize =
uiLayout.dialogueFontSize into initializeDialogueInterface so the
narration uses the same configurable narration font size from
Behavior.config as TheLastSpark scenes. Also adjust commented
env.book/env.goPage lines to enable BTree_test narration and keep
TheLastSpark disabled; verified no diagnostics errors.
Use Behavior book and robust scene loading

Enable TheLastSpark behavior book and make scene module loading more
robust by adding kwiksher kwik path entries and checking require with
pcall before calling composer.gotoScene. This prevents crashes when a
scene module fails to load and ensures the correct module search paths
include kwiksher's kwik modules.

Also commented out test env settings, unifies env.book/env.goPage
selection for TheLastSpark, and added a cabin handoff plan detailing
namespace unification, fixes for missing modules, UI resiliency, and
diagnostics to address missing-audio and next-button visibility issues.
Move behavior base modules out of views

Remove helper/base modules from views folders and update requires to
reference Behavior.* directly. Files like baseScene, choice_base,
display_base, and display_manager were deleted from views in both
Behavior/BTree_test and Behavior/TheLastSpark, and all require calls
(e.g. require("views.baseScene")) were changed to use Behavior paths.
Also restore and simplify package.path setup in main.lua to load
Behavior/<book> modules correctly.